### PR TITLE
feat(frontend): 🎸 add character limit to mission input

### DIFF
--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -364,7 +364,7 @@ fields:
       table: Mission
       data_type: character varying
       default_value: null
-      max_length: 255
+      max_length: 50
       numeric_precision: null
       numeric_scale: null
       is_nullable: false

--- a/frontend/src/lib/certificate-generator/generate-certificate.ts
+++ b/frontend/src/lib/certificate-generator/generate-certificate.ts
@@ -204,8 +204,10 @@ export const generateNftCertificate = async (
 	},
 ): Promise<File> => {
 	try {
+		const truncatedMission = mission.length > 50 ? `${mission.slice(0, 50).trim()}..` : mission
+
 		const svgString = await prepareCertificate(qrUrl, {
-			mission: mission,
+			mission: truncatedMission,
 			operationsManager: operationsManager,
 			dateOfWork: dateOfWork,
 			bidiEarned: bidiEarned,


### PR DESCRIPTION
- this PR adds a simple limit and check on mission input, so the text doesn't overlap certificate width.